### PR TITLE
set a local user.email so tests work for developers that require this…

### DIFF
--- a/ModuloKitTests/TestScenarios.swift
+++ b/ModuloKitTests/TestScenarios.swift
@@ -30,6 +30,8 @@ class TestScenarios: XCTestCase {
         
         runCommand("git init")
         
+        runCommand("git config --local user.email foo@example.com")
+        
         var result = Modulo.run(["init", "--app"])
         XCTAssertTrue(result == .success)
         
@@ -60,7 +62,7 @@ class TestScenarios: XCTestCase {
         XCTAssertTrue(result == .success)
         
         runCommand("git add -A")
-        runCommand("git commit -m \"initial with modulo adds\"")
+        testCommit("initial with modulo adds")
         
         // the main project should be clean now.
         result = Modulo.run(["status"])
@@ -72,6 +74,8 @@ class TestScenarios: XCTestCase {
         XCTAssertTrue(status == .success)
         
         FileManager.setWorkingPath("test-simeon")
+        
+        runCommand("git config --local user.email foo@example.com")
         
         var result = Modulo.run(["init", "--app"])
         XCTAssertTrue(result == .success)
@@ -103,7 +107,7 @@ class TestScenarios: XCTestCase {
         XCTAssertTrue(result == .success)
         
         runCommand("git add -A")
-        runCommand("git commit -m \"initial with modulo adds\"")
+        testCommit("initial with modulo adds")
         
         // the main project should have unpushed commits now.
         result = Modulo.run(["status"])

--- a/ModuloKitTests/TestStatus.swift
+++ b/ModuloKitTests/TestStatus.swift
@@ -70,12 +70,14 @@ class TestStatus: XCTestCase {
         
         FileManager.setWorkingPath("test-add")
         
+        runCommand("git config --local user.email foo@example.com")
+        
         var result = Modulo.run(["update", "--all", "-v"])
         XCTAssertTrue(result == .success)
         
         touchFile("blah.txt")
         runCommand("git add blah.txt")
-        runCommand("git commit -m \"test\"")
+        testCommit("test")
         
         result = Modulo.run(["status", "-v"])
         XCTAssertTrue(result == .dependencyUnclean)
@@ -91,6 +93,8 @@ class TestStatus: XCTestCase {
         
         FileManager.setWorkingPath("test-add")
         
+        runCommand("git config --local user.email foo@example.com")
+        
         var result = Modulo.run(["update", "--all", "-v"])
         XCTAssertTrue(result == .success)
         
@@ -98,7 +102,7 @@ class TestStatus: XCTestCase {
         
         touchFile("blah.txt")
         runCommand("git add blah.txt")
-        runCommand("git commit -m \"test\"")
+        testCommit("test")
         
         FileManager.setWorkingPath("../test-add")
         

--- a/ModuloKitTests/Utils.swift
+++ b/ModuloKitTests/Utils.swift
@@ -33,3 +33,7 @@ func touchFile(_ path: String) {
 func runCommand(_ command: String) {
     Git().runCommand(command)
 }
+
+func testCommit(_ message: String) {
+    Git().runCommand("git commit -m \"\(message)\" --no-verify")
+}


### PR DESCRIPTION
… setting

Some of the unit tests failed for me because I have my local world set up to require a local user.email configuration. This commit makes sure one is set where needed.