### PR TITLE
Support tracking dependencies by branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # By default export all variables
 export
 
-.PHONY: install release debug build setup clean
+.PHONY: install release debug build setup clean test
 
 PROJECT ?= 'modulo.xcodeproj'
 SCHEME  ?= 'modulo'
@@ -10,6 +10,9 @@ CONFIGURATION ?= 'Debug'
 
 # Build for debugging
 debug: build
+
+test:
+	xcodebuild -project $(PROJECT) -scheme ModuloKit test
 
 # Install `modulo` to `/usr/local/bin`
 install: release

--- a/Modules/ELCLI/ELCLI/CLI.swift
+++ b/Modules/ELCLI/ELCLI/CLI.swift
@@ -154,7 +154,20 @@ open class CLI {
                             // it's a "--flag value" type argument.
                             if index < arguments.count - 1 {
                                 value = arguments[index + 1]
-                                skipNext = true
+                                // If we're assuming `--flag value` make sure
+                                // our `value` isn't a stop marker or flag. If it is
+                                // our value should instead be `nil`'d out so our
+                                // command does not get a value where it is our next
+                                // argument.
+                                if let argValue = value,
+                                    isStopMarker(argValue) || isFlag(argValue) {
+                                    value = nil
+                                } else {
+                                    // However if that's not the case we should skip
+                                    // the next command because we really did get
+                                    // `--flag value`
+                                    skipNext = true
+                                }
                             }
                         }
                     }

--- a/Modules/ELCLI/ELCLI/Options.swift
+++ b/Modules/ELCLI/ELCLI/Options.swift
@@ -11,10 +11,10 @@ import Foundation
 public typealias OptionClosure = (_ option: String?, _ value: String?) -> Void
 
 public struct Option {
-    public let usage: String?
-    public let flags: Array<String>?
-    public let valueSignatures: Array<String>?
-    public let closure: OptionClosure
+    let usage: String?
+    let flags: Array<String>?
+    let valueSignatures: Array<String>?
+    let closure: OptionClosure
     
     init(flags: Array<String>?, usage: String?, valueSignatures: Array<String>?, closure: @escaping OptionClosure) {
         self.flags = flags

--- a/Modules/ELCLI/ELCLI/Options.swift
+++ b/Modules/ELCLI/ELCLI/Options.swift
@@ -11,10 +11,10 @@ import Foundation
 public typealias OptionClosure = (_ option: String?, _ value: String?) -> Void
 
 public struct Option {
-    let usage: String?
-    let flags: Array<String>?
-    let valueSignatures: Array<String>?
-    let closure: OptionClosure
+    public let usage: String?
+    public let flags: Array<String>?
+    public let valueSignatures: Array<String>?
+    public let closure: OptionClosure
     
     init(flags: Array<String>?, usage: String?, valueSignatures: Array<String>?, closure: @escaping OptionClosure) {
         self.flags = flags

--- a/ModuloKit/Actions.swift
+++ b/ModuloKit/Actions.swift
@@ -22,8 +22,8 @@ open class Actions {
         }
     }
     
-    open func addDependency(_ url: String, version: SemverRange?, branch: String?, unmanaged: Bool) -> ErrorCode {
-        let dep = DependencySpec(repositoryURL: url, version: version, branch: branch)
+    open func addDependency(_ url: String, version: SemverRange?, unmanagedValue: String?, unmanaged: Bool) -> ErrorCode {
+        let dep = DependencySpec(repositoryURL: url, version: version, unmanagedValue: unmanagedValue)
         if var workingSpec = ModuleSpec.workingSpec() {
             // does this dep already exist in here??
             if let _ = workingSpec.dependencyForURL(url) {
@@ -77,8 +77,8 @@ open class Actions {
                         exit(checkoutResult.errorMessage())
                     }
                 }
-                if let branch = dep.branch {
-                    let checkoutResult = scm.checkout(branch: branch, path: clonePath)
+                if let unmanagedValue = dep.unmanagedValue {
+                    let checkoutResult = scm.checkout(branchOrHash: unmanagedValue, path: clonePath)
                     if checkoutResult != .success {
                         exit(checkoutResult.errorMessage())
                     }
@@ -102,7 +102,7 @@ open class Actions {
                 }
                 
                 // if they're unmanaged and on a branch, tracking a remote, just do a pull
-                if dep.unmanaged == true, let currentBranch = scm.branchName(clonePath) {
+                if dep.unmanaged == true && dep.unmanagedValue == nil, let currentBranch = scm.branchName(clonePath) {
                     if scm.remoteTrackingBranch(currentBranch) != nil {
                         let pullResult = scm.pull(clonePath, remoteData: nil)
                         if pullResult != .success {
@@ -116,13 +116,13 @@ open class Actions {
                         if checkoutResult != .success {
                             exit(checkoutResult.errorMessage())
                         }
-                    } else if let branch = dep.branch {
-                        let checkoutResult = scm.checkout(branch: branch, path: clonePath)
+                    } else if let unmanagedValue = dep.unmanagedValue {
+                        let checkoutResult = scm.checkout(branchOrHash: unmanagedValue, path: clonePath)
                         if checkoutResult != .success {
                             exit(checkoutResult.errorMessage())
                         }
                     } else {
-                        exit("\(dep.name()) doesn't have a version, branch, and isn't marked as 'unmanaged', not sure what to do.")
+                        exit("\(dep.name()) doesn't have a version and isn't marked as 'unmanaged', not sure what to do.")
                     }
                 }
             }

--- a/ModuloKit/Commands/AddCommand.swift
+++ b/ModuloKit/Commands/AddCommand.swift
@@ -44,21 +44,7 @@ open class AddCommand: NSObject, Command {
         
         addOptionValue(["--unmanaged"], usage: "specifies that this module will be unmanaged", valueSignature: "<[hash|branch|nothing]>") { (option, value) -> Void in
             self.unmanaged = true
-            if let value = value {
-                if !value.hasPrefix("-") {
-                    self.unmanagedValue = value
-                }  else {
-                    if self.verbose {
-                        writeln(.stderr, "Assuming '\(value)' is a flag and not a branch/commit hash since it begins with '-' and will not track it.")
-                    }
-                    // TODO: Somehow reprocess this `value` as a flag
-                    self.options.filter({ (option) -> Bool in
-                        option.flags?.contains(value) ??  false
-                    }).forEach({ (option) in
-                        option.closure(value, nil)
-                    })
-                }
-            }
+            self.unmanagedValue = value
         }
         
         addOption(["-u", "--update"], usage: "performs the update command after adding a module") { (option, value) in

--- a/ModuloKit/Commands/AddCommand.swift
+++ b/ModuloKit/Commands/AddCommand.swift
@@ -16,6 +16,7 @@ import Foundation
 open class AddCommand: NSObject, Command {
     // internal properties
     fileprivate var version: SemverRange? = nil
+    fileprivate var branch: String? = nil
     fileprivate var repositoryURL: String! = nil
     fileprivate var shouldUpdate: Bool = false
     fileprivate var unmanaged: Bool = false
@@ -40,6 +41,12 @@ open class AddCommand: NSObject, Command {
                 self.version = SemverRange(value)
             }
         }
+
+        addOptionValue(["--branch"], usage: "specify the branch to track", valueSignature: "<branch>") { (option, value) in
+            if let value = value {
+                self.branch = value
+            }
+        }
         
         addOption(["--unmanaged"], usage: "specifies that this module will be unmanaged") { (option, value) in
             self.unmanaged = true
@@ -57,8 +64,8 @@ open class AddCommand: NSObject, Command {
     open func execute(_ otherParams: Array<String>?) -> Int {
         let actions = Actions()
         
-        if version == nil && unmanaged == false {
-            writeln(.stderr, "A version or range must be specified via --version, or --unmanaged must be used.")
+        if version == nil && branch == nil && unmanaged == false {
+            writeln(.stderr, "A version or range must be specified via --version, a branch must be specified via --branch, or --unmanaged must be used.")
             return ErrorCode.commandError.rawValue
         }
         
@@ -69,7 +76,7 @@ open class AddCommand: NSObject, Command {
             }
         }
 
-        let result = actions.addDependency(repositoryURL, version: version, unmanaged: unmanaged)
+        let result = actions.addDependency(repositoryURL, version: version, branch: branch, unmanaged: unmanaged)
         if result == .success {
             if shouldUpdate {
                 writeln(.stdout, "Added \(String(describing: repositoryURL)).")

--- a/ModuloKit/SCM/SCM.swift
+++ b/ModuloKit/SCM/SCM.swift
@@ -76,6 +76,7 @@ public protocol SCM {
     func fetch(_ path: String) -> SCMResult
     func pull(_ path: String, remoteData: String?) -> SCMResult
     func checkout(version: SemverRange, path: String) -> SCMResult
+    func checkout(branch: String, path: String) -> SCMResult
     func remove(_ path: String) -> SCMResult
     func adjustIgnoreFile(pattern: String, removing: Bool) -> SCMResult
     func checkStatus(_ path: String) -> SCMResult

--- a/ModuloKit/SCM/SCM.swift
+++ b/ModuloKit/SCM/SCM.swift
@@ -76,7 +76,9 @@ public protocol SCM {
     func fetch(_ path: String) -> SCMResult
     func pull(_ path: String, remoteData: String?) -> SCMResult
     func checkout(version: SemverRange, path: String) -> SCMResult
-    func checkout(branch: String, path: String) -> SCMResult
+    /// Check out an arbitrary point or the HEAD of a branch (in git)
+    /// or the equivalent in other SCM solutions
+    func checkout(branchOrHash: String, path: String) -> SCMResult
     func remove(_ path: String) -> SCMResult
     func adjustIgnoreFile(pattern: String, removing: Bool) -> SCMResult
     func checkStatus(_ path: String) -> SCMResult

--- a/ModuloKit/Specs/DependencySpec.swift
+++ b/ModuloKit/Specs/DependencySpec.swift
@@ -17,10 +17,12 @@ public struct DependencySpec {
     var repositoryURL: String
     // version or version range
     var version: SemverRange?
+    /// Branch to track
+    var branch: String?
 
     var unmanaged: Bool {
         get {
-            return (version == nil)
+            return (version == nil) && (branch == nil)
         }
     }
 }
@@ -29,7 +31,8 @@ extension DependencySpec: ELDecodable {
     public static func decode(_ json: JSON?) throws -> DependencySpec {
         return try DependencySpec(
             repositoryURL: json ==> "repositoryURL",
-            version: json ==> "version"
+            version: json ==> "version",
+            branch: json ==> "branch"
         )
     }
     
@@ -42,7 +45,8 @@ extension DependencySpec: ELEncodable {
     public func encode() throws -> JSON {
         return try encodeToJSON([
             "repositoryURL" <== repositoryURL,
-            "version" <== version
+            "version" <== version,
+            "branch" <== branch
         ])
     }
 }

--- a/ModuloKit/Specs/DependencySpec.swift
+++ b/ModuloKit/Specs/DependencySpec.swift
@@ -17,12 +17,13 @@ public struct DependencySpec {
     var repositoryURL: String
     // version or version range
     var version: SemverRange?
-    /// Branch to track
-    var branch: String?
+    /// Optional unmanaged property to track
+    /// such as a branch name, commit hash, or nothing
+    var unmanagedValue: String?
 
     var unmanaged: Bool {
         get {
-            return (version == nil) && (branch == nil)
+            return (version == nil)
         }
     }
 }
@@ -32,7 +33,7 @@ extension DependencySpec: ELDecodable {
         return try DependencySpec(
             repositoryURL: json ==> "repositoryURL",
             version: json ==> "version",
-            branch: json ==> "branch"
+            unmanagedValue: json ==> "unmanagedValue"
         )
     }
     
@@ -46,7 +47,7 @@ extension DependencySpec: ELEncodable {
         return try encodeToJSON([
             "repositoryURL" <== repositoryURL,
             "version" <== version,
-            "branch" <== branch
+            "unmanagedValue" <== unmanagedValue
         ])
     }
 }

--- a/ModuloKitTests/TestAdd.swift
+++ b/ModuloKitTests/TestAdd.swift
@@ -78,4 +78,33 @@ class TestAdd: XCTestCase {
 
         FileManager.setWorkingPath("..")
     }
+
+    func testAddModuleByBranch() {
+        let status = Git().clone("git@github.com:modulo-dm/test-add.git", path: "test-add")
+        XCTAssertTrue(status == .success)
+
+        FileManager.setWorkingPath("test-add")
+
+        let repoURL = "git@github.com:modulo-dm/test-add-update.git"
+
+        let result = Modulo.run(["add", repoURL, "--branch", "master", "-v"])
+        XCTAssertTrue(result == .success)
+
+
+        guard let spec = ModuleSpec.load(contentsOfFile: specFilename) else {
+            XCTFail("Failed to get spec from file \(specFilename)")
+            return }
+        XCTAssertTrue(spec.dependencies.count > 0)
+        guard let dep = spec.dependencyForURL(repoURL) else {
+            XCTFail("Failed to find dependency for url \(repoURL) in spec \(spec)")
+            return }
+        XCTAssertNil(dep.version)
+        XCTAssertFalse(dep.unmanaged)
+        XCTAssertNotNil(dep.branch)
+        XCTAssertTrue(dep.branch == "master")
+
+        FileManager.setWorkingPath("..")
+
+        Git().remove("test-add")
+    }
 }

--- a/ModuloKitTests/TestAdd.swift
+++ b/ModuloKitTests/TestAdd.swift
@@ -79,7 +79,7 @@ class TestAdd: XCTestCase {
         FileManager.setWorkingPath("..")
     }
 
-    func testAddModuleByBranch() {
+    func testAddUnmanagedModuleWithBranch() {
         let status = Git().clone("git@github.com:modulo-dm/test-add.git", path: "test-add")
         XCTAssertTrue(status == .success)
 
@@ -87,7 +87,7 @@ class TestAdd: XCTestCase {
 
         let repoURL = "git@github.com:modulo-dm/test-add-update.git"
 
-        let result = Modulo.run(["add", repoURL, "--branch", "master", "-v"])
+        let result = Modulo.run(["add", repoURL, "--unmanaged", "master", "-v"])
         XCTAssertTrue(result == .success)
 
 
@@ -99,9 +99,37 @@ class TestAdd: XCTestCase {
             XCTFail("Failed to find dependency for url \(repoURL) in spec \(spec)")
             return }
         XCTAssertNil(dep.version)
-        XCTAssertFalse(dep.unmanaged)
-        XCTAssertNotNil(dep.branch)
-        XCTAssertTrue(dep.branch == "master")
+        XCTAssertTrue(dep.unmanaged)
+        XCTAssertNotNil(dep.unmanagedValue)
+        XCTAssertTrue(dep.unmanagedValue == "master")
+
+        FileManager.setWorkingPath("..")
+
+        Git().remove("test-add")
+    }
+
+    func testAddModuleUnmanagedNoArgs() {
+        let status = Git().clone("git@github.com:modulo-dm/test-add.git", path: "test-add")
+        XCTAssertTrue(status == .success)
+
+        FileManager.setWorkingPath("test-add")
+
+        let repoURL = "git@github.com:modulo-dm/test-add-update.git"
+
+        let result = Modulo.run(["add", repoURL, "--unmanaged", "-v"])
+        XCTAssertTrue(result == .success)
+
+
+        guard let spec = ModuleSpec.load(contentsOfFile: specFilename) else {
+            XCTFail("Failed to get spec from file \(specFilename)")
+            return }
+        XCTAssertTrue(spec.dependencies.count > 0)
+        guard let dep = spec.dependencyForURL(repoURL) else {
+            XCTFail("Failed to find dependency for url \(repoURL) in spec \(spec)")
+            return }
+        XCTAssertNil(dep.version)
+        XCTAssertTrue(dep.unmanaged)
+        XCTAssertNil(dep.unmanagedValue)
 
         FileManager.setWorkingPath("..")
 

--- a/ModuloKitTests/TestDummyApp.swift
+++ b/ModuloKitTests/TestDummyApp.swift
@@ -41,7 +41,7 @@ class TestDummyApp: XCTestCase {
         XCTAssertTrue(spec!.dependencyForURL("git@github.com:modulo-dm/test-add-update.git") != nil)
         
         let checkedOut = Git().branchName("modules/test-add-update")
-        XCTAssertTrue(checkedOut == "master")
+        XCTAssertTrue(checkedOut == "master", "checkedOut should have been 'master' but was '\(String(describing: checkedOut))'")
         
         XCTAssertTrue(FileManager.fileExists("modules/test-add-update"))
         XCTAssertTrue(FileManager.fileExists("modules/test-dep1"))

--- a/modulo.xcodeproj/xcshareddata/xcschemes/modulo.xcscheme
+++ b/modulo.xcodeproj/xcshareddata/xcschemes/modulo.xcscheme
@@ -69,11 +69,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "defaults --set --alwaysVerbose true"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "update --verbose"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "update"


### PR DESCRIPTION
In addition to `version` and all the features around that, we can also
explicitly track a remote `branch` that will be fetched/updated when
`modulo update` is run.

Add `make test` command
Lets make running tests easier by adding a Make command for it